### PR TITLE
fixed bug in stat rolling in CharCreation.java

### DIFF
--- a/com/planet_ink/coffee_mud/Libraries/CharCreation.java
+++ b/com/planet_ink/coffee_mud/Libraries/CharCreation.java
@@ -2837,23 +2837,24 @@ public class CharCreation extends StdLibrary implements CharCreationLibrary
 		final boolean randomRoll = CMProps.getIntVar(CMProps.Int.STARTSTAT) == 0;
 		if(randomRoll)
 		{
-			loginObj.baseStats.copyInto(mob.baseCharStats());
-			mob.baseCharStats().setWearableRestrictionsBitmap(0);
-			reRollStats(mob.baseCharStats(),loginObj.statPoints);
-			mob.recoverCharStats();
 			if(!CMSecurity.isDisabled(CMSecurity.DisFlag.CLASSES))
 			{
-				qualifyingClassListV=classQualifies(mob,loginObj.theme);
 				for(int i=0;i<50 && qualifyingClassListV.size()==0;i++)
 				{
+					loginObj.baseStats.copyInto(mob.baseCharStats());
+					mob.baseCharStats().setWearableRestrictionsBitmap(0);
 					reRollStats(mob.baseCharStats(),loginObj.statPoints);
 					mob.recoverCharStats();
 					qualifyingClassListV=classQualifies(mob,loginObj.theme);
 				}
+			} else {
+				loginObj.baseStats.copyInto(mob.baseCharStats());
+				mob.baseCharStats().setWearableRestrictionsBitmap(0);
+				reRollStats(mob.baseCharStats(),loginObj.statPoints);
+				mob.recoverCharStats();
+				qualifyingClassListV=classQualifies(mob,loginObj.theme);
 			}
 		}
-		mob.recoverCharStats();
-		qualifyingClassListV=classQualifies(mob,loginObj.theme);
 
 		if(!randomRoll || (qualifyingClassListV.size()>0) || CMSecurity.isDisabled(CMSecurity.DisFlag.CLASSES))
 		{


### PR DESCRIPTION
Previously, if the rolled dice didn't qualify a char for anything, the inner loop would call reRollStats() without properly resetting mob.baseCharStats(). This resulted in either the character getting massive bonuses or the reRollStats() method going into an infinite loop trying to allocate points after all stats were maxed out.