### PR TITLE
New instance depricated

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,329 @@
+### Eclipse settings ###
+
+# from URL https://github.com/github/gitignore
+
+.metadata
+bin/
+tmp/
+*.tmp
+*.bak
+*.swp
+*~.nib
+local.properties
+.settings/
+.loadpath
+.recommenders
+
+# not sure about these two
+.classpath
+.project
+
+# External tool builders
+.externalToolBuilders/
+
+# Locally stored "Eclipse launch configurations"
+*.launch
+
+# PyDev specific (Python IDE for Eclipse)
+*.pydevproject
+
+# CDT-specific (C/C++ Development Tooling)
+.cproject
+
+# CDT- autotools
+.autotools
+
+# Java annotation processor (APT)
+.factorypath
+
+# PDT-specific (PHP Development Tools)
+.buildpath
+
+# sbteclipse plugin
+.target
+
+# Tern plugin
+.tern-project
+
+# TeXlipse plugin
+.texlipse
+
+# STS (Spring Tool Suite)
+.springBeans
+
+# Code Recommenders
+.recommenders/
+
+# Annotation Processing
+.apt_generated/
+.apt_generated_test/
+
+# Scala IDE specific (Scala & Java development for Eclipse)
+.cache-main
+.scala_dependencies
+.worksheet
+
+# Uncomment this line if you wish to ignore the project description file.
+# Typically, this file would be tracked if it contains build/dependency configurations:
+#.project
+
+
+### Git ###
+
+# Created by git for backups. To disable backups in Git:
+# $ git config --global mergetool.keepBackup false
+*.orig
+
+# Created by git when using merge tools for conflicts
+*.BACKUP.*
+*.BASE.*
+*.LOCAL.*
+*.REMOTE.*
+*_BACKUP_*.txt
+*_BASE_*.txt
+*_LOCAL_*.txt
+*_REMOTE_*.txt
+
+### Java ###
+
+# Compiled class file
+*.class
+
+# Log file
+*.log
+
+# BlueJ files
+*.ctxt
+
+# Mobile Tools for Java (J2ME)
+.mtj.tmp/
+
+# Package Files #
+*.jar
+*.war
+*.nar
+*.ear
+*.zip
+*.tar.gz
+*.rar
+
+# virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
+hs_err_pid*
+
+### JetBrains ###
+
+# Covers JetBrains IDEs: IntelliJ, RubyMine, PhpStorm, AppCode, PyCharm, CLion, Android Studio, WebStorm and Rider
+# Reference: https://intellij-support.jetbrains.com/hc/en-us/articles/206544839
+
+# User-specific stuff
+.idea/**/workspace.xml
+.idea/**/tasks.xml
+.idea/**/usage.statistics.xml
+.idea/**/dictionaries
+.idea/**/shelf
+
+# AWS User-specific
+.idea/**/aws.xml
+
+# Generated files
+.idea/**/contentModel.xml
+
+# Sensitive or high-churn files
+.idea/**/dataSources/
+.idea/**/dataSources.ids
+.idea/**/dataSources.local.xml
+.idea/**/sqlDataSources.xml
+.idea/**/dynamic.xml
+.idea/**/uiDesigner.xml
+.idea/**/dbnavigator.xml
+
+# Gradle
+.idea/**/gradle.xml
+.idea/**/libraries
+
+# Gradle and Maven with auto-import
+# When using Gradle or Maven with auto-import, you should exclude module files,
+# since they will be recreated, and may cause churn.  Uncomment if using
+# auto-import.
+# .idea/artifacts
+# .idea/compiler.xml
+# .idea/jarRepositories.xml
+# .idea/modules.xml
+# .idea/*.iml
+# .idea/modules
+# *.iml
+# *.ipr
+
+# CMake
+cmake-build-*/
+
+# Mongo Explorer plugin
+.idea/**/mongoSettings.xml
+
+# File-based project format
+*.iws
+
+# IntelliJ
+out/
+
+# mpeltonen/sbt-idea plugin
+.idea_modules/
+
+# JIRA plugin
+atlassian-ide-plugin.xml
+
+# Cursive Clojure plugin
+.idea/replstate.xml
+
+# Crashlytics plugin (for Android Studio and IntelliJ)
+com_crashlytics_export_strings.xml
+crashlytics.properties
+crashlytics-build.properties
+fabric.properties
+
+# Editor-based Rest Client
+.idea/httpRequests
+
+# Android studio 3.1+ serialized cache file
+.idea/caches/build_file_checksums.ser
+
+### macOS ###
+
+# General
+.DS_Store
+.AppleDouble
+.LSOverride
+
+# Icon must end with two \r
+Icon
+
+# Thumbnails
+._*
+
+# Files that might appear in the root of a volume
+.DocumentRevisions-V100
+.fseventsd
+.Spotlight-V100
+.TemporaryItems
+.Trashes
+.VolumeIcon.icns
+.com.apple.timemachine.donotpresent
+
+# Directories potentially created on remote AFP share
+.AppleDB
+.AppleDesktop
+Network Trash Folder
+Temporary Items
+.apdisk
+
+### Linux Settings ###
+
+*~
+
+# temporary files which can be created if a process still has a handle open of a deleted file
+.fuse_hidden*
+
+# KDE directory preferences
+.directory
+
+# Linux trash folder which might appear on any partition or disk
+.Trash-*
+
+# .nfs files are created when an open file is removed but is still being accessed
+.nfs*
+
+### Maven ###
+
+target/
+pom.xml.tag
+pom.xml.releaseBackup
+pom.xml.versionsBackup
+pom.xml.next
+release.properties
+dependency-reduced-pom.xml
+buildNumber.properties
+.mvn/timing.properties
+.mvn/wrapper/maven-wrapper.jar
+
+### Netbeans ###
+
+**/nbproject/private/
+**/nbproject/Makefile-*.mk
+**/nbproject/Package-*.bash
+build/
+nbbuild/
+dist/
+nbdist/
+.nb-gradle/
+
+### Subversion ###
+
+.svn/
+
+### TortoisGit ###
+
+# Project-level settings
+
+/.tgitconfig
+
+### Vim ###
+
+# Swap
+[._]*.s[a-v][a-z]
+!*.svg  # comment out if you don't need vector files
+[._]*.sw[a-p]
+[._]s[a-rt-v][a-z]
+[._]ss[a-gi-z]
+[._]sw[a-p]
+
+# Session
+Session.vim
+Sessionx.vim
+
+# Temporary
+.netrwhist
+*~
+# Auto-generated tag files
+tags
+# Persistent undo
+[._]*.un~
+
+### Visual Studio Code ###
+
+.vscode/*
+!.vscode/settings.json
+!.vscode/tasks.json
+!.vscode/launch.json
+!.vscode/extensions.json
+*.code-workspace
+
+# Local History for Visual Studio Code
+.history/
+
+### MS Windows ###
+
+# Windows thumbnail cache files
+Thumbs.db
+Thumbs.db:encryptable
+ehthumbs.db
+ehthumbs_vista.db
+
+# Dump file
+*.stackdump
+
+# Folder config file
+[Dd]esktop.ini
+
+# Recycle Bin used on file shares
+$RECYCLE.BIN/
+
+# Windows Installer files
+*.cab
+*.msi
+*.msix
+*.msm
+*.msp
+
+# Windows shortcuts
+*.lnk
+

--- a/com/planet_ink/coffee_mud/Abilities/Common/GenCraftSkill.java
+++ b/com/planet_ink/coffee_mud/Abilities/Common/GenCraftSkill.java
@@ -189,7 +189,7 @@ public class GenCraftSkill extends EnhancedCraftingSkill implements ItemCraftor
 	{
 		try
 		{
-			final GenCraftSkill A=this.getClass().newInstance();
+			final GenCraftSkill A=this.getClass().getDeclaredConstructor().newInstance();
 			A.ID=ID;
 			return A;
 		}

--- a/com/planet_ink/coffee_mud/Abilities/Common/GenGatheringSkill.java
+++ b/com/planet_ink/coffee_mud/Abilities/Common/GenGatheringSkill.java
@@ -164,7 +164,7 @@ public class GenGatheringSkill extends GatheringSkill implements ItemCollection
 	{
 		try
 		{
-			final GenGatheringSkill A=this.getClass().newInstance();
+			final GenGatheringSkill A=this.getClass().getDeclaredConstructor().newInstance();
 			A.ID=ID;
 			return A;
 		}

--- a/com/planet_ink/coffee_mud/Abilities/GenAbility.java
+++ b/com/planet_ink/coffee_mud/Abilities/GenAbility.java
@@ -301,7 +301,7 @@ public class GenAbility extends StdAbility
 	{
 		try
 		{
-			final GenAbility A = this.getClass().newInstance();
+			final GenAbility A = this.getClass().getDeclaredConstructor().newInstance();
 			A.ID=ID;
 			getScripter();
 			A.scriptParmHash=scriptParmHash;

--- a/com/planet_ink/coffee_mud/Abilities/Languages/GenLanguage.java
+++ b/com/planet_ink/coffee_mud/Abilities/Languages/GenLanguage.java
@@ -134,7 +134,7 @@ public class GenLanguage extends StdLanguage
 	{
 		try
 		{
-			final GenLanguage A=this.getClass().newInstance();
+			final GenLanguage A=this.getClass().getDeclaredConstructor().newInstance();
 			A.ID=ID;
 			return A;
 		}

--- a/com/planet_ink/coffee_mud/Abilities/Misc/QuestBound.java
+++ b/com/planet_ink/coffee_mud/Abilities/Misc/QuestBound.java
@@ -429,7 +429,7 @@ public class QuestBound implements Ability
 	{
 		try
 		{
-			return this.getClass().newInstance();
+			return this.getClass().getDeclaredConstructor().newInstance();
 		}
 		catch (final Exception e)
 		{

--- a/com/planet_ink/coffee_mud/Abilities/Properties/Prop_MultiEffects.java
+++ b/com/planet_ink/coffee_mud/Abilities/Properties/Prop_MultiEffects.java
@@ -324,7 +324,7 @@ public class Prop_MultiEffects extends Property
 	{
 		try
 		{
-			final Prop_MultiEffects pA =this.getClass().newInstance();
+			final Prop_MultiEffects pA =this.getClass().getDeclaredConstructor().newInstance();
 			pA.setMiscText(text());
 			return pA;
 		}
@@ -443,4 +443,3 @@ public class Prop_MultiEffects extends Property
 			A.executeMsg(myHost, msg);
 	}
 }
-

--- a/com/planet_ink/coffee_mud/Abilities/Properties/Property.java
+++ b/com/planet_ink/coffee_mud/Abilities/Properties/Property.java
@@ -114,7 +114,7 @@ public class Property extends ThinAbility
 	{
 		try
 		{
-			return this.getClass().newInstance();
+			return this.getClass().getDeclaredConstructor().newInstance();
 		}
 		catch (final Exception e)
 		{

--- a/com/planet_ink/coffee_mud/Abilities/StdAbility.java
+++ b/com/planet_ink/coffee_mud/Abilities/StdAbility.java
@@ -76,7 +76,7 @@ public class StdAbility implements Ability
 	{
 		try
 		{
-			return this.getClass().newInstance();
+			return this.getClass().getDeclaredConstructor().newInstance();
 		}
 		catch(final Exception e)
 		{

--- a/com/planet_ink/coffee_mud/Abilities/ThinAbility.java
+++ b/com/planet_ink/coffee_mud/Abilities/ThinAbility.java
@@ -436,7 +436,7 @@ public class ThinAbility implements Ability
 	{
 		try
 		{
-			return this.getClass().newInstance();
+			return this.getClass().getDeclaredConstructor().newInstance();
 		}
 		catch (final Exception e)
 		{

--- a/com/planet_ink/coffee_mud/Areas/StdArea.java
+++ b/com/planet_ink/coffee_mud/Areas/StdArea.java
@@ -682,7 +682,7 @@ public class StdArea implements Area
 		}
 		try
 		{
-			return this.getClass().newInstance();
+			return this.getClass().getDeclaredConstructor().newInstance();
 		}
 		catch (final Exception e)
 		{

--- a/com/planet_ink/coffee_mud/Areas/StdBoardableShip.java
+++ b/com/planet_ink/coffee_mud/Areas/StdBoardableShip.java
@@ -500,7 +500,7 @@ public class StdBoardableShip implements Area, Boardable, PrivateProperty
 	{
 		try
 		{
-			return this.getClass().newInstance();
+			return this.getClass().getDeclaredConstructor().newInstance();
 		}
 		catch(final Exception e)
 		{

--- a/com/planet_ink/coffee_mud/Areas/StdSpaceShip.java
+++ b/com/planet_ink/coffee_mud/Areas/StdSpaceShip.java
@@ -364,7 +364,7 @@ public class StdSpaceShip extends StdBoardableShip implements SpaceShip
 	{
 		try
 		{
-			return this.getClass().newInstance();
+			return this.getClass().getDeclaredConstructor().newInstance();
 		}
 		catch(final Exception e)
 		{

--- a/com/planet_ink/coffee_mud/Behaviors/StdBehavior.java
+++ b/com/planet_ink/coffee_mud/Behaviors/StdBehavior.java
@@ -96,7 +96,7 @@ public class StdBehavior implements Behavior
 	{
 		try
 		{
-			return this.getClass().newInstance();
+			return this.getClass().getDeclaredConstructor().newInstance();
 		}
 		catch(final Exception e)
 		{

--- a/com/planet_ink/coffee_mud/Behaviors/WaterCurrents.java
+++ b/com/planet_ink/coffee_mud/Behaviors/WaterCurrents.java
@@ -655,7 +655,7 @@ public class WaterCurrents extends ActiveTicker
 		{
 			try
 			{
-				return this.getClass().newInstance();
+				return this.getClass().getDeclaredConstructor().newInstance();
 			}
 			catch (final Exception e)
 			{

--- a/com/planet_ink/coffee_mud/CharClasses/GenCharClass.java
+++ b/com/planet_ink/coffee_mud/CharClasses/GenCharClass.java
@@ -380,7 +380,7 @@ public class GenCharClass extends StdCharClass
 	{
 		try
 		{
-			return getClass().newInstance();
+			return getClass().getDeclaredConstructor().newInstance();
 		}
 		catch (final Exception e)
 		{

--- a/com/planet_ink/coffee_mud/Commands/Load.java
+++ b/com/planet_ink/coffee_mud/Commands/Load.java
@@ -254,7 +254,7 @@ public class Load extends StdCommand
 						{
 							C=Class.forName("com.sun.tools.javac.Main", true, CMClass.instance());
 							if(C!=null)
-								CO=C.newInstance();
+								CO=C.getDeclaredConstructor().newInstance();
 						}
 						catch(final Exception e)
 						{

--- a/com/planet_ink/coffee_mud/Common/AuctionCoffeeShop.java
+++ b/com/planet_ink/coffee_mud/Common/AuctionCoffeeShop.java
@@ -83,7 +83,7 @@ public class AuctionCoffeeShop implements CoffeeShop
 	{
 		try
 		{
-			return getClass().newInstance();
+			return getClass().getDeclaredConstructor().newInstance();
 		}
 		catch(final Exception e)
 		{

--- a/com/planet_ink/coffee_mud/Common/DefaultAbilityComponent.java
+++ b/com/planet_ink/coffee_mud/Common/DefaultAbilityComponent.java
@@ -63,7 +63,7 @@ public class DefaultAbilityComponent implements AbilityComponent
 	{
 		try
 		{
-			return getClass().newInstance();
+			return getClass().getDeclaredConstructor().newInstance();
 		}
 		catch (final Exception e)
 		{

--- a/com/planet_ink/coffee_mud/Common/DefaultArrestWarrant.java
+++ b/com/planet_ink/coffee_mud/Common/DefaultArrestWarrant.java
@@ -56,7 +56,7 @@ public class DefaultArrestWarrant implements LegalWarrant
 	{
 		try
 		{
-			return getClass().newInstance();
+			return getClass().getDeclaredConstructor().newInstance();
 		}
 		catch (final Exception e)
 		{

--- a/com/planet_ink/coffee_mud/Common/DefaultAuction.java
+++ b/com/planet_ink/coffee_mud/Common/DefaultAuction.java
@@ -68,7 +68,7 @@ public class DefaultAuction implements AuctionData
 	{
 		try
 		{
-			return getClass().newInstance();
+			return getClass().getDeclaredConstructor().newInstance();
 		}
 		catch (final Exception e)
 		{

--- a/com/planet_ink/coffee_mud/Common/DefaultCharState.java
+++ b/com/planet_ink/coffee_mud/Common/DefaultCharState.java
@@ -60,7 +60,7 @@ public class DefaultCharState implements CharState
 	{
 		try
 		{
-			return getClass().newInstance();
+			return getClass().getDeclaredConstructor().newInstance();
 		}
 		catch (final Exception e)
 		{

--- a/com/planet_ink/coffee_mud/Common/DefaultCharStats.java
+++ b/com/planet_ink/coffee_mud/Common/DefaultCharStats.java
@@ -55,7 +55,7 @@ public class DefaultCharStats implements CharStats
 	{
 		try
 		{
-			final DefaultCharStats newStats=getClass().newInstance();
+			final DefaultCharStats newStats=getClass().getDeclaredConstructor().newInstance();
 			if(newStats.myRace==null)
 				newStats.myRace=CMClass.getRace("StdRace");
 			return newStats;

--- a/com/planet_ink/coffee_mud/Common/DefaultClan.java
+++ b/com/planet_ink/coffee_mud/Common/DefaultClan.java
@@ -121,7 +121,7 @@ public class DefaultClan implements Clan
 	{
 		try
 		{
-			return getClass().newInstance();
+			return getClass().getDeclaredConstructor().newInstance();
 		}
 		catch (final Exception e)
 		{

--- a/com/planet_ink/coffee_mud/Common/DefaultClanGovernment.java
+++ b/com/planet_ink/coffee_mud/Common/DefaultClanGovernment.java
@@ -137,7 +137,7 @@ public class DefaultClanGovernment implements ClanGovernment
 	{
 		try
 		{
-			return getClass().newInstance();
+			return getClass().getDeclaredConstructor().newInstance();
 		}
 		catch (final Exception e)
 		{

--- a/com/planet_ink/coffee_mud/Common/DefaultClanPosition.java
+++ b/com/planet_ink/coffee_mud/Common/DefaultClanPosition.java
@@ -73,7 +73,7 @@ public class DefaultClanPosition implements ClanPosition
 	{
 		try
 		{
-			return getClass().newInstance();
+			return getClass().getDeclaredConstructor().newInstance();
 		}
 		catch(final Exception e)
 		{

--- a/com/planet_ink/coffee_mud/Common/DefaultClimate.java
+++ b/com/planet_ink/coffee_mud/Common/DefaultClimate.java
@@ -63,7 +63,7 @@ public class DefaultClimate implements Climate
 	{
 		try
 		{
-			return getClass().newInstance();
+			return getClass().getDeclaredConstructor().newInstance();
 		}
 		catch (final Exception e)
 		{

--- a/com/planet_ink/coffee_mud/Common/DefaultCoffeeShop.java
+++ b/com/planet_ink/coffee_mud/Common/DefaultCoffeeShop.java
@@ -133,7 +133,7 @@ public class DefaultCoffeeShop implements CoffeeShop
 	{
 		try
 		{
-			return getClass().newInstance();
+			return getClass().getDeclaredConstructor().newInstance();
 		}
 		catch (final Exception e)
 		{

--- a/com/planet_ink/coffee_mud/Common/DefaultCoffeeTableRow.java
+++ b/com/planet_ink/coffee_mud/Common/DefaultCoffeeTableRow.java
@@ -278,7 +278,7 @@ public class DefaultCoffeeTableRow implements CoffeeTableRow
 	{
 		try
 		{
-			return getClass().newInstance();
+			return getClass().getDeclaredConstructor().newInstance();
 		}
 		catch (final Exception e)
 		{

--- a/com/planet_ink/coffee_mud/Common/DefaultFaction.java
+++ b/com/planet_ink/coffee_mud/Common/DefaultFaction.java
@@ -56,7 +56,7 @@ public class DefaultFaction implements Faction, MsgListener
 	{
 		try
 		{
-			return getClass().newInstance();
+			return getClass().getDeclaredConstructor().newInstance();
 		}
 		catch (final Exception e)
 		{

--- a/com/planet_ink/coffee_mud/Common/DefaultHttpClient.java
+++ b/com/planet_ink/coffee_mud/Common/DefaultHttpClient.java
@@ -80,7 +80,7 @@ public class DefaultHttpClient implements HttpClient, Cloneable
 	{
 		try
 		{
-			return getClass().newInstance();
+			return getClass().getDeclaredConstructor().newInstance();
 		}
 		catch(final Exception e)
 		{

--- a/com/planet_ink/coffee_mud/Common/DefaultJournalEntry.java
+++ b/com/planet_ink/coffee_mud/Common/DefaultJournalEntry.java
@@ -71,7 +71,7 @@ public class DefaultJournalEntry implements JournalEntry
 	{
 		try
 		{
-			return getClass().newInstance();
+			return getClass().getDeclaredConstructor().newInstance();
 		}
 		catch (final Exception e)
 		{

--- a/com/planet_ink/coffee_mud/Common/DefaultLawSet.java
+++ b/com/planet_ink/coffee_mud/Common/DefaultLawSet.java
@@ -55,7 +55,7 @@ public class DefaultLawSet implements Law
 	{
 		try
 		{
-			return getClass().newInstance();
+			return getClass().getDeclaredConstructor().newInstance();
 		}
 		catch(final Exception e)
 		{

--- a/com/planet_ink/coffee_mud/Common/DefaultManufacturer.java
+++ b/com/planet_ink/coffee_mud/Common/DefaultManufacturer.java
@@ -65,7 +65,7 @@ public class DefaultManufacturer implements Manufacturer
 	{
 		try
 		{
-			return getClass().newInstance();
+			return getClass().getDeclaredConstructor().newInstance();
 		}
 		catch(final Exception e)
 		{

--- a/com/planet_ink/coffee_mud/Common/DefaultMessage.java
+++ b/com/planet_ink/coffee_mud/Common/DefaultMessage.java
@@ -52,7 +52,7 @@ public class DefaultMessage implements CMMsg
 	{
 		try
 		{
-			return getClass().newInstance();
+			return getClass().getDeclaredConstructor().newInstance();
 		}
 		catch (final Exception e)
 		{
@@ -321,7 +321,7 @@ public class DefaultMessage implements CMMsg
 			suspendTrailers=newValue.booleanValue();
 		return this.suspendTrailers;
 	}
-	
+
 	@Override
 	public CMMsg addTrailerMsg(final CMMsg msg)
 	{

--- a/com/planet_ink/coffee_mud/Common/DefaultPhyStats.java
+++ b/com/planet_ink/coffee_mud/Common/DefaultPhyStats.java
@@ -312,7 +312,7 @@ public class DefaultPhyStats implements PhyStats
 	{
 		try
 		{
-			return getClass().newInstance();
+			return getClass().getDeclaredConstructor().newInstance();
 		}
 		catch (final Exception e)
 		{

--- a/com/planet_ink/coffee_mud/Common/DefaultPlayerAccount.java
+++ b/com/planet_ink/coffee_mud/Common/DefaultPlayerAccount.java
@@ -95,7 +95,7 @@ public class DefaultPlayerAccount implements PlayerAccount
 	{
 		try
 		{
-			return getClass().newInstance();
+			return getClass().getDeclaredConstructor().newInstance();
 		}
 		catch(final Exception e)
 		{

--- a/com/planet_ink/coffee_mud/Common/DefaultPlayerStats.java
+++ b/com/planet_ink/coffee_mud/Common/DefaultPlayerStats.java
@@ -142,7 +142,7 @@ public class DefaultPlayerStats implements PlayerStats
 	{
 		try
 		{
-			return getClass().newInstance();
+			return getClass().getDeclaredConstructor().newInstance();
 		}
 		catch(final Exception e)
 		{

--- a/com/planet_ink/coffee_mud/Common/DefaultPoll.java
+++ b/com/planet_ink/coffee_mud/Common/DefaultPoll.java
@@ -53,7 +53,7 @@ public class DefaultPoll implements Poll
 	{
 		try
 		{
-			return getClass().newInstance();
+			return getClass().getDeclaredConstructor().newInstance();
 		}
 		catch (final Exception e)
 		{

--- a/com/planet_ink/coffee_mud/Common/DefaultQuest.java
+++ b/com/planet_ink/coffee_mud/Common/DefaultQuest.java
@@ -276,7 +276,7 @@ public class DefaultQuest implements Quest, Tickable, CMObject
 	{
 		try
 		{
-			return getClass().newInstance();
+			return getClass().getDeclaredConstructor().newInstance();
 		}
 		catch (final Exception e)
 		{

--- a/com/planet_ink/coffee_mud/Common/DefaultRoomnumberSet.java
+++ b/com/planet_ink/coffee_mud/Common/DefaultRoomnumberSet.java
@@ -64,7 +64,7 @@ public class DefaultRoomnumberSet implements RoomnumberSet
 	{
 		try
 		{
-			return getClass().newInstance();
+			return getClass().getDeclaredConstructor().newInstance();
 		}
 		catch(final Exception e)
 		{

--- a/com/planet_ink/coffee_mud/Common/DefaultScriptingEngine.java
+++ b/com/planet_ink/coffee_mud/Common/DefaultScriptingEngine.java
@@ -412,7 +412,7 @@ public class DefaultScriptingEngine implements ScriptingEngine
 	{
 		try
 		{
-			return this.getClass().newInstance();
+			return this.getClass().getDeclaredConstructor().newInstance();
 		}
 		catch(final Exception e)
 		{

--- a/com/planet_ink/coffee_mud/Common/DefaultSession.java
+++ b/com/planet_ink/coffee_mud/Common/DefaultSession.java
@@ -165,7 +165,7 @@ public class DefaultSession implements Session
 	{
 		try
 		{
-			return getClass().newInstance();
+			return getClass().getDeclaredConstructor().newInstance();
 		}
 		catch (final Exception e)
 		{
@@ -3391,7 +3391,7 @@ public class DefaultSession implements Session
 		{
 			try
 			{
-				return getClass().newInstance();
+				return getClass().getDeclaredConstructor().newInstance();
 			}
 			catch (final Exception e)
 			{

--- a/com/planet_ink/coffee_mud/Common/DefaultTimeClock.java
+++ b/com/planet_ink/coffee_mud/Common/DefaultTimeClock.java
@@ -53,7 +53,7 @@ public class DefaultTimeClock implements TimeClock
 	{
 		try
 		{
-			return getClass().newInstance();
+			return getClass().getDeclaredConstructor().newInstance();
 		}
 		catch (final Exception e)
 		{

--- a/com/planet_ink/coffee_mud/Common/FakeSession.java
+++ b/com/planet_ink/coffee_mud/Common/FakeSession.java
@@ -68,7 +68,7 @@ public class FakeSession implements Session
 	{
 		try
 		{
-			return getClass().newInstance();
+			return getClass().getDeclaredConstructor().newInstance();
 		}
 		catch (final Exception e)
 		{

--- a/com/planet_ink/coffee_mud/Exits/StdExit.java
+++ b/com/planet_ink/coffee_mud/Exits/StdExit.java
@@ -293,7 +293,7 @@ public class StdExit implements Exit
 	{
 		try
 		{
-			return this.getClass().newInstance();
+			return this.getClass().getDeclaredConstructor().newInstance();
 		}
 		catch(final Exception e)
 		{

--- a/com/planet_ink/coffee_mud/Items/Basic/GenWallpaper.java
+++ b/com/planet_ink/coffee_mud/Items/Basic/GenWallpaper.java
@@ -187,7 +187,7 @@ public class GenWallpaper implements Item
 	{
 		try
 		{
-			return this.getClass().newInstance();
+			return this.getClass().getDeclaredConstructor().newInstance();
 		}
 		catch (final Exception e)
 		{

--- a/com/planet_ink/coffee_mud/Items/Basic/StdItem.java
+++ b/com/planet_ink/coffee_mud/Items/Basic/StdItem.java
@@ -224,7 +224,7 @@ public class StdItem implements Item
 	{
 		try
 		{
-			return this.getClass().newInstance();
+			return this.getClass().getDeclaredConstructor().newInstance();
 		}
 		catch(final Exception e)
 		{

--- a/com/planet_ink/coffee_mud/Items/Weapons/Sword.java
+++ b/com/planet_ink/coffee_mud/Items/Weapons/Sword.java
@@ -66,7 +66,7 @@ public class Sword extends StdWeapon
 		{
 			try
 			{
-				return this.getClass().newInstance();
+				return this.getClass().getDeclaredConstructor().newInstance();
 			}
 			catch(final Exception e)
 			{
@@ -92,7 +92,7 @@ public class Sword extends StdWeapon
 		default:
 			try
 			{
-				return this.getClass().newInstance();
+				return this.getClass().getDeclaredConstructor().newInstance();
 			}
 			catch(final Exception e)
 			{

--- a/com/planet_ink/coffee_mud/Libraries/CMChannels.java
+++ b/com/planet_ink/coffee_mud/Libraries/CMChannels.java
@@ -997,7 +997,7 @@ public class CMChannels extends StdLibrary implements ChannelsLibrary
 		try
 		{
 			final Class<?> cbClass = Class.forName("twitter4j.conf.ConfigurationBuilder");
-			final Object cbObj = cbClass.newInstance();
+			final Object cbObj = cbClass.getDeclaredConstructor().newInstance();
 			final Method cbM1=cbClass.getMethod("setOAuthConsumerKey", String.class);
 			cbM1.invoke(cbObj,CMProps.getProp("TWITTER-OAUTHCONSUMERKEY"));
 			final Method cbM2=cbClass.getMethod("setOAuthConsumerSecret", String.class);
@@ -1016,7 +1016,7 @@ public class CMChannels extends StdLibrary implements ChannelsLibrary
 
 			final Class<?> auClass = Class.forName("twitter4j.auth.Authorization");
 			final Class<?> tfClass = Class.forName("twitter4j.TwitterFactory");
-			final Object tfObj = tfClass.newInstance();
+			final Object tfObj = tfClass.getDeclaredConstructor().newInstance();
 			final Method tfM1 = tfClass.getMethod("getInstance", auClass);
 			final Object twObj = tfM1.invoke(tfObj, auObj);
 

--- a/com/planet_ink/coffee_mud/Libraries/MUDPercolator.java
+++ b/com/planet_ink/coffee_mud/Libraries/MUDPercolator.java
@@ -188,7 +188,7 @@ public class MUDPercolator extends StdLibrary implements AreaGenerationLibrary
 		{
 			try
 			{
-				return mgr.newInstance();
+				return mgr.getDeclaredConstructor().newInstance();
 			}
 			catch(final Exception e)
 			{

--- a/com/planet_ink/coffee_mud/Libraries/StdLibrary.java
+++ b/com/planet_ink/coffee_mud/Libraries/StdLibrary.java
@@ -46,7 +46,7 @@ public class StdLibrary implements CMLibrary, Tickable
 	{
 		try
 		{
-			return this.getClass().newInstance();
+			return this.getClass().getDeclaredConstructor().newInstance();
 		}
 		catch(final Exception e)
 		{

--- a/com/planet_ink/coffee_mud/Libraries/XMLManager.java
+++ b/com/planet_ink/coffee_mud/Libraries/XMLManager.java
@@ -18,6 +18,7 @@ import com.planet_ink.coffee_mud.Races.interfaces.*;
 
 import java.lang.reflect.Array;
 import java.lang.reflect.Field;
+import java.lang.reflect.InvocationTargetException;
 import java.util.*;
 
 import com.planet_ink.coffee_mud.Libraries.interfaces.*;
@@ -1786,7 +1787,7 @@ public class XMLManager extends StdLibrary implements XMLLibrary
 							}
 							else
 							{
-								final Object newObj = cType.newInstance();
+								final Object newObj = cType.getDeclaredConstructor().newInstance();
 								fromXMLtoPOJO(vTag.contents(), newObj);
 								Array.set(tgt, i, newObj);
 							}
@@ -1844,7 +1845,7 @@ public class XMLManager extends StdLibrary implements XMLLibrary
 						field.set(o, Boolean.valueOf(valTag.value()));
 					else
 					{
-						final Object newObj = field.getType().newInstance();
+						final Object newObj = field.getType().getDeclaredConstructor().newInstance();
 						fromXMLtoPOJO(valTag.contents(), newObj);
 						field.set(o, newObj);
 					}
@@ -1859,6 +1860,14 @@ public class XMLManager extends StdLibrary implements XMLLibrary
 				throw new IllegalArgumentException(e.getMessage(),e);
 			}
 			catch (final InstantiationException e)
+			{
+				throw new IllegalArgumentException(e.getMessage(),e);
+			}
+			catch (final NoSuchMethodException e)
+			{
+				throw new IllegalArgumentException(e.getMessage(),e);
+			}
+			catch (final InvocationTargetException e)
 			{
 				throw new IllegalArgumentException(e.getMessage(),e);
 			}

--- a/com/planet_ink/coffee_mud/Locales/StdRoom.java
+++ b/com/planet_ink/coffee_mud/Locales/StdRoom.java
@@ -106,7 +106,7 @@ public class StdRoom implements Room
 	{
 		try
 		{
-			return this.getClass().newInstance();
+			return this.getClass().getDeclaredConstructor().newInstance();
 		}
 		catch(final Exception e)
 		{

--- a/com/planet_ink/coffee_mud/Locales/ThinRoom.java
+++ b/com/planet_ink/coffee_mud/Locales/ThinRoom.java
@@ -1087,7 +1087,7 @@ public class ThinRoom implements Room
 	{
 		try
 		{
-			return this.getClass().newInstance();
+			return this.getClass().getDeclaredConstructor().newInstance();
 		}
 		catch (final Exception e)
 		{

--- a/com/planet_ink/coffee_mud/MOBS/StdFactoryMOB.java
+++ b/com/planet_ink/coffee_mud/MOBS/StdFactoryMOB.java
@@ -51,7 +51,7 @@ public class StdFactoryMOB extends StdMOB
 	{
 		try
 		{
-			return this.getClass().newInstance();
+			return this.getClass().getDeclaredConstructor().newInstance();
 		}
 		catch(final Exception e)
 		{

--- a/com/planet_ink/coffee_mud/MOBS/StdMOB.java
+++ b/com/planet_ink/coffee_mud/MOBS/StdMOB.java
@@ -456,7 +456,7 @@ public class StdMOB implements MOB
 	{
 		try
 		{
-			return this.getClass().newInstance();
+			return this.getClass().getDeclaredConstructor().newInstance();
 		}
 		catch (final Exception e)
 		{

--- a/com/planet_ink/coffee_mud/Races/GenRace.java
+++ b/com/planet_ink/coffee_mud/Races/GenRace.java
@@ -319,7 +319,7 @@ public class GenRace extends StdRace
 	{
 		try
 		{
-			return getClass().newInstance();
+			return getClass().getDeclaredConstructor().newInstance();
 		}
 		catch (final Exception e)
 		{

--- a/com/planet_ink/coffee_mud/application/VFShell.java
+++ b/com/planet_ink/coffee_mud/application/VFShell.java
@@ -169,7 +169,7 @@ public class VFShell
 					Log.errOut("Database error! Panic shutdown!");
 					System.exit(-1);
 				}
-				
+
 				CMClass.initialize();
 				Resources.initialize();
 				CMSecurity.instance();
@@ -226,7 +226,7 @@ public class VFShell
 					{
 						try
 						{
-							return getClass().newInstance();
+							return getClass().getDeclaredConstructor().newInstance();
 						}
 						catch (final Exception e)
 						{

--- a/com/planet_ink/coffee_mud/core/CMClass.java
+++ b/com/planet_ink/coffee_mud/core/CMClass.java
@@ -1571,7 +1571,7 @@ public class CMClass extends ClassLoader
 		{
 			final String pathLess=makeDotClassPath(path);
 			if(classes.containsKey(pathLess))
-				return (classes.get(pathLess)).newInstance();
+				return (classes.get(pathLess)).getDeclaredConstructor().newInstance();
 		}
 		catch(final Exception e)
 		{
@@ -1584,7 +1584,7 @@ public class CMClass extends ClassLoader
 		final Object o = V.firstElement();
 		try
 		{
-			return o.getClass().newInstance();
+			return o.getClass().getDeclaredConstructor().newInstance();
 		}
 		catch(final Exception e)
 		{
@@ -1659,7 +1659,7 @@ public class CMClass extends ClassLoader
 			shortThis=shortThis.substring(x+1);
 			try
 			{
-				return classes.get(calledThis).newInstance();
+				return classes.get(calledThis).getDeclaredConstructor().newInstance();
 			}
 			catch (final Exception e)
 			{
@@ -2451,7 +2451,7 @@ public class CMClass extends ClassLoader
 							Log.sysOut("CMClass","WARNING: class failed ancestral check: "+packageName);
 					}
 					else
-						O=C.newInstance();
+						O=C.getDeclaredConstructor().newInstance();
 				}
 				if(O==null)
 				{

--- a/com/planet_ink/coffee_mud/core/MiniJSON.java
+++ b/com/planet_ink/coffee_mud/core/MiniJSON.java
@@ -350,7 +350,7 @@ public class MiniJSON
 				newObj.put(key, jsonDeepCopy(this.get(key)));
 			return newObj;
 		}
-		
+
 		public void putString(final String key, final String value)
 		{
 			if(value == null)
@@ -918,7 +918,7 @@ public class MiniJSON
 							else
 							if(objs[i] instanceof JSONObject)
 							{
-								final Object newObj = cType.newInstance();
+								final Object newObj = cType.getDeclaredConstructor().newInstance();
 								fromJSONtoPOJO((JSONObject)objs[i], newObj);
 								Array.set(tgt, i, newObj);
 							}
@@ -958,7 +958,7 @@ public class MiniJSON
 					else
 					if(jo instanceof JSONObject)
 					{
-						final Object newObj = field.getType().newInstance();
+						final Object newObj = field.getType().getDeclaredConstructor().newInstance();
 						fromJSONtoPOJO((JSONObject)jo, newObj);
 						field.set(o, newObj);
 					}
@@ -996,6 +996,14 @@ public class MiniJSON
 				throw new MJSONException(e.getMessage(),e);
 			}
 			catch (final InstantiationException e)
+			{
+				throw new MJSONException(e.getMessage(),e);
+			}
+			catch (final NoSuchMethodException e)
+			{
+				throw new MJSONException(e.getMessage(),e);
+			}
+			catch (final InvocationTargetException e)
 			{
 				throw new MJSONException(e.getMessage(),e);
 			}

--- a/com/planet_ink/coffee_mud/core/intermud/IMudClient.java
+++ b/com/planet_ink/coffee_mud/core/intermud/IMudClient.java
@@ -58,7 +58,7 @@ public class IMudClient implements I3Interface
 	{
 		try
 		{
-			return getClass().newInstance();
+			return getClass().getDeclaredConstructor().newInstance();
 		}
 		catch(final Exception e)
 		{

--- a/com/planet_ink/coffee_mud/core/intermud/i3/server/ServerThread.java
+++ b/com/planet_ink/coffee_mud/core/intermud/i3/server/ServerThread.java
@@ -106,7 +106,7 @@ public class ServerThread implements Tickable
 
 		try
 		{
-			ob = (ServerObject)Class.forName(str).newInstance();
+			ob = (ServerObject)Class.forName(str).getDeclaredConstructor().newInstance();
 			count++;
 			str = str + "#" + count;
 			ob.setObjectId(str);
@@ -138,7 +138,7 @@ public class ServerThread implements Tickable
 		{
 			try
 			{
-				ob = (ServerObject)Class.forName(str).newInstance();
+				ob = (ServerObject)Class.forName(str).getDeclaredConstructor().newInstance();
 				ob.setObjectId(str);
 				objects.put(str, ob);
 			}
@@ -196,7 +196,7 @@ public class ServerThread implements Tickable
 		try
 		{
 			Intermud.setup(intermuds,
-						   (PersistentPeer)Class.forName("com.planet_ink.coffee_mud.core.intermud.i3.IMudPeer").newInstance());
+						   (PersistentPeer)Class.forName("com.planet_ink.coffee_mud.core.intermud.i3.IMudPeer").getDeclaredConstructor().newInstance());
 		}
 		catch( final Exception e )
 		{

--- a/com/planet_ink/coffee_mud/core/smtp/SMTPserver.java
+++ b/com/planet_ink/coffee_mud/core/smtp/SMTPserver.java
@@ -64,7 +64,7 @@ public class SMTPserver extends Thread implements Tickable
 	{
 		try
 		{
-			return getClass().newInstance();
+			return getClass().getDeclaredConstructor().newInstance();
 		}
 		catch(final Exception e)
 		{

--- a/com/planet_ink/coffee_mud/core/threads/ServiceEngine.java
+++ b/com/planet_ink/coffee_mud/core/threads/ServiceEngine.java
@@ -76,7 +76,7 @@ public class ServiceEngine implements ThreadEngine
 	{
 		try
 		{
-			return getClass().newInstance();
+			return getClass().getDeclaredConstructor().newInstance();
 		}
 		catch (final Exception e)
 		{

--- a/com/planet_ink/coffee_web/http/HTTPException.java
+++ b/com/planet_ink/coffee_web/http/HTTPException.java
@@ -204,7 +204,7 @@ public class HTTPException extends Exception
 					final Class<? extends HTTPOutputConverter> converterClass=config.getConverters().findConverter(mimeType);
 					if(converterClass != null)
 					{
-						final HTTPOutputConverter converter=converterClass.newInstance();
+						final HTTPOutputConverter converter=converterClass.getDeclaredConstructor().newInstance();
 						finalBody=new CWDataBuffers(converter.convertOutput(config, request, errorFile, status, fileBytes.flushToBuffer()),0,true);
 					}
 					else

--- a/com/planet_ink/coffee_web/http/HTTPReqProcessor.java
+++ b/com/planet_ink/coffee_web/http/HTTPReqProcessor.java
@@ -463,7 +463,7 @@ public class HTTPReqProcessor implements HTTPFileGetter
 			try
 			{
 				stats.startProcessing(); // synchronization is not required, so long as endProcessing is always called
-				final SimpleServlet servletInstance = servletClass.newInstance(); // instantiate a new servlet instance!
+				final SimpleServlet servletInstance = servletClass.getDeclaredConstructor().newInstance(); // instantiate a new servlet instance!
 				if(request.getMethod() == HTTPMethod.GET)
 					servletInstance.doGet(servletRequest, servletResponse);
 				else
@@ -639,7 +639,7 @@ public class HTTPReqProcessor implements HTTPFileGetter
 				HTTPOutputConverter converter;
 				try
 				{
-					converter = converterClass.newInstance();
+					converter = converterClass.getDeclaredConstructor().newInstance();
 					return new CWDataBuffers(converter.convertOutput(config, request, pathFile, HTTPStatus.S200_OK, buffers.flushToBuffer()), System.currentTimeMillis(), true);
 				}
 				catch (final Exception e)
@@ -729,7 +729,7 @@ public class HTTPReqProcessor implements HTTPFileGetter
 						try
 						{
 							HTTPOutputConverter converter;
-							converter = converterClass.newInstance();
+							converter = converterClass.getDeclaredConstructor().newInstance();
 							extraHeaders.put(HTTPHeader.Common.CACHE_CONTROL, "no-cache");
 							final long dateTime=System.currentTimeMillis();
 							if(dateTime >= 0)

--- a/com/planet_ink/coffee_web/http/ServletManager.java
+++ b/com/planet_ink/coffee_web/http/ServletManager.java
@@ -109,7 +109,7 @@ public class ServletManager implements SimpleServletManager
 			SimpleServlet servlet;
 			try
 			{
-				servlet = c.newInstance();
+				servlet = c.getDeclaredConstructor().newInstance();
 				servlet.init();
 			}
 			catch (final Exception e)

--- a/com/planet_ink/coffee_web/util/CWConfig.java
+++ b/com/planet_ink/coffee_web/util/CWConfig.java
@@ -1337,7 +1337,7 @@ public class CWConfig implements Cloneable
 				{
 					try
 					{
-						tree=treeClass.newInstance();
+						tree=treeClass.getDeclaredConstructor().newInstance();
 						portMap.put(from.second, tree);
 					}
 					catch (final Exception e)

--- a/com/planet_ink/fakedb/DBUpgrade.java
+++ b/com/planet_ink/fakedb/DBUpgrade.java
@@ -256,7 +256,7 @@ public class DBUpgrade
 									try
 									{
 										C = Class.forName(value);
-										O = C.newInstance();
+										O = C.getDeclaredConstructor().newInstance();
 									}
 									catch (final Throwable t)
 									{


### PR DESCRIPTION
Bo, I am testing against Java17, and one of the warnings I have received is that .newInstance() is depricated.  The fix is to replace it with '.getDeclaredConstructor().newInstance()'.  This patch does so, and fixes a few un-caught exceptions.