### PR TITLE
Monkey Grip weapon attack/damage adjustments fix

### DIFF
--- a/com/planet_ink/coffee_mud/Abilities/Fighter/Fighter_MonkeyGrip.java
+++ b/com/planet_ink/coffee_mud/Abilities/Fighter/Fighter_MonkeyGrip.java
@@ -160,9 +160,9 @@ public class Fighter_MonkeyGrip extends FighterSkill
 			else
 			{
 				final double pctLoss=0.75 - CMath.mul(.50 + (.05 * super.getXLEVELLevel(M)), CMath.div(proficiency(),100));
-				affectableStats.setDamage(affectableStats.damage()-(int)Math.round(CMath.div(affectableStats.damage(), pctLoss)));
+				affectableStats.setDamage(affectableStats.damage()-(int)Math.round(CMath.mul(affectableStats.damage(), pctLoss)));
 				if(affectableStats.attackAdjustment()>0)
-					affectableStats.setAttackAdjustment(affectableStats.attackAdjustment()-(int)Math.round(CMath.div(affectableStats.attackAdjustment(), pctLoss)));
+					affectableStats.setAttackAdjustment(affectableStats.attackAdjustment()-(int)Math.round(CMath.mul(affectableStats.attackAdjustment(), pctLoss)));
 			}
 		}
 		else


### PR DESCRIPTION
Fixed damage/attack modification formulae on weapons when Monkey Grip is applied to them (previous formula would result in total negative damage or divide by zero)