### PR TITLE
Fix small logic bug in CorpseEater behavior

### DIFF
--- a/com/planet_ink/coffee_mud/Behaviors/CorpseEater.java
+++ b/com/planet_ink/coffee_mud/Behaviors/CorpseEater.java
@@ -146,7 +146,7 @@ public class CorpseEater extends ActiveTicker
 							continue;
 					}
 					else
-					if(eatMobs)
+					if(!eatMobs)
 						continue;
 					if((maskStr.length()>0) || (mask != null))
 					{


### PR DESCRIPTION
CorpseEater doesn't actually work to eat mob corpses.  Small typo in if/else logic fixes. 